### PR TITLE
Lock cryptography version and add requirements.in comments

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Django==2.2.*
+Django==2.2.*  # Latest LTS version
 django-environ
 django-extensions
 requests
@@ -24,4 +24,4 @@ werkzeug
 pip-tools
 
 # Security
-cryptography>=3.3.2  # 2021-3-4
+cryptography==3.3.2  # Lock to 3.3.2 if running into "No module named 'setuptools_rust'" error

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ chardet==3.0.4
     # via requests
 click==7.1.2
     # via pip-tools
-cryptography==3.4.6
+cryptography==3.3.2
     # via
     #   -r requirements.in
     #   social-auth-core
@@ -83,6 +83,7 @@ requests==2.25.0
     #   social-auth-core
 six==1.15.0
     # via
+    #   cryptography
     #   social-auth-app-django
     #   social-auth-core
     #   traitlets


### PR DESCRIPTION
`cryptography` versions greater than 3.3.2 sometimes give `No module named 'setuptools_rust'...try upgrading pip` errors even when pip is upgraded (probably due to OS or python version?)

https://github.com/Azure/azure-cli/issues/16858
https://github.com/frappe/bench/issues/1117