### PR TITLE
Add --ignore *.scss to collectstatic

### DIFF
--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -32,7 +32,7 @@ container_commands:
   05_collectstatic:
     command: |
         source $PYTHONPATH/activate
-        python manage.py collectstatic --noinput
+        python manage.py collectstatic --noinput --ignore *.scss
 
 option_settings:
   aws:elasticbeanstalk:environment:proxy:

--- a/readme.md
+++ b/readme.md
@@ -183,8 +183,14 @@ Note: If you aren't already using npm to install bootstrap, you can alternativel
 files directly into your static directory and change your references to point there. There is currently no good way to
 install Bootstrap source code using just python.
 
+#### Production notes
 
-## Sentry integration (`sentry`)
+In development, `.scss` files are compiled on the fly. However, when deploying, these files must be manually generated
+using `python manage.py compilescss`. Also note that if your styles folder is in a directory that's collected with
+`collectstatic`, you should add the `--ignore *.scss` flag to avoid exposing the raw `.scss` files as staticfiles.
+
+
+### Sentry integration (`sentry`)
 
 ### Docker integration (`docker`)
 


### PR DESCRIPTION
Issue:

The current sample Django app setup exposes raw `.scss` staticfiles. This is because we include the `styles` folder for `.scss` files inside `static`, for which `collectstatic` would collect in order to be served as staticfiles. While the raw `.scss` files would not be linked to in the source code, one could deduce that given `/static/base.css` is a valid staticfile, you could also visit `/static/base.scss`.

This is not likely to be a serious issue, but worth considering out of principle.

Potential solutions:

1. (This PR's solution) Simply add `--ignore *.scss` to `python manage.py collectstatic` in any deploy steps. This is the simplest solution, but also prone to be easily forgotten or missed. Given the low severity, it may be an acceptable tradeoff.
2. Don't do anything about it.
3. Theoretically, move the `styles` folder outside of any `STATICFILES_DIRS` and add `sass_processor.finders.CssFinder` to `STATICFILES_FINDERS`. Moving the `styles` folder outside of `STATICFILES_DIRS` prevents `collectstatic` from copying the raw `.scss`files and the `sass_processor.finders.CssFinder` will collect just the compiled `.css` files. This adds quite a bit of folder structure complexity/nuance which is easily lost, and in brief testing, it doesn't work as expected (`.css` files are not collected as indicated in the package readme).
4. Subclass the existing `STATICFILES_FINDERS` to ignore `.scss`. This is a lot of extra code, prone to breaking, and easily missed when adding new finders.