### PR TITLE
Include cfn-init-cmd.log when requesting logs through AWS console

### DIFF
--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -68,4 +68,11 @@ files:
       "\e[A":history-search-backward
       ## arrow down
       "\e[B":history-search-forward
+
+  "/opt/elasticbeanstalk/tasks/taillogs.d/cfn-init-cmd.conf":
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      /var/log/cfn-init-cmd.log
 # END_FEATURE elastic_beanstalk


### PR DESCRIPTION
cfn-init-cmd.log contains the output of the various deployment commands. For example, when migrate fails because of missing environment variables, cfn-init-cmd.log will have the text of that error.

Files in `/opt/elasticbeanstalk/tasks/taillogs.d/` contain the path to log files to include when requesting logs from the Elastic Beanstalk console.