### PR TITLE
Only include debug_toolbar in installed apps if DEBUG_TOOLBAR is True

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -64,6 +64,10 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: do not run with debug turned on in production!
 DEBUG = env("DEBUG")
 
+# START_FEATURE debug_toolbar
+DEBUG_TOOLBAR = DEBUG and env("DEBUG_TOOLBAR")
+# END_FEATURE debug_toolbar
+
 # run with this set to False on server environments
 LOCALHOST = env("LOCALHOST")
 
@@ -106,14 +110,16 @@ THIRD_PARTY_APPS = [
     "webpack_loader",
     # END_FEATURE django_react
 
-    # START_FEATURE debug_toolbar
-    "debug_toolbar",
-    # END_FEATURE debug_toolbar
-
     # START_FEATURE sass_bootstrap
     "sass_processor",
     # END_FEATURE sass_bootstrap
 ]
+
+
+# START_FEATURE debug_toolbar
+if DEBUG_TOOLBAR:
+    THIRD_PARTY_APPS += ["debug_toolbar"]
+# END_FEATURE debug_toolbar
 
 LOCAL_APPS = [
     "common",
@@ -308,7 +314,6 @@ else:
 
 
 # START_FEATURE debug_toolbar
-DEBUG_TOOLBAR = DEBUG and env("DEBUG_TOOLBAR")
 INTERNAL_IPS = ['127.0.0.1']
 if DEBUG_TOOLBAR:
     MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')


### PR DESCRIPTION
Only include debug toolbar in installed apps if DEBUG_TOOLBAR is True. This fixes an issue with deploying production code using requirements instead of dev-requirements.