### PR TITLE
Permit configuring ALLOWED_HOSTS in LOCALHOST mode

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -77,7 +77,8 @@ PRODUCTION = env("PRODUCTION")
 
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 if LOCALHOST is True:
-    ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
+    ALLOWED_HOSTS += ["127.0.0.1", "localhost"]
+    CSRF_TRUSTED_ORIGINS = [f"http://{host}" for host in ALLOWED_HOSTS] + [f"https://{host}" for host in ALLOWED_HOSTS]
 else:
     ALLOWED_HOSTS.append("localhost")
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -48,7 +48,7 @@ env = environ.Env(
     DEBUG_TOOLBAR=(bool, False),
     # END_FEATURE debug_toolbar
 )
-# If ALLWED_HOSTS has been configured, then we're running on a server and
+# If ALLOWED_HOSTS has been configured, then we're running on a server and
 # can skip looking for a .env file (this assumes that .env files
 # file is only used for local development and servers use environment variables)
 if not env("ALLOWED_HOSTS"):


### PR DESCRIPTION
When developing, it might be desirable to connect via a different hostname.

For example, configuring a custom hostname in `/etc/hosts` such that a password manager can differentiate between projects for autofill.

Additionally can be used to allow connecting via other devices on local network (to test mobile view) by allowing adding the server's local IP to `ALLOWED_HOSTS` (and separately configuring firewall)

Also fix CSRF in these cases, especially in combination with a self-run https reverse proxy (e.g. `tailscale serve`, also useful for testing mobile view)